### PR TITLE
Add a prop 'displayCustom' to render custom components in the centre

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#Unreleased
+* Added `displayCustom`, which allows ability to render custom component in the centre of the knob, if `displayInput` is set to false.
+
+
 # 0.3.0
 * Added boolean property `disableTextInput`
 * Switched `touchStart` from React SyntheticEvent to vanilla DOM event handler

--- a/Knob.js
+++ b/Knob.js
@@ -26,6 +26,7 @@ class Knob extends React.Component {
     readOnly: React.PropTypes.bool,
     disableTextInput: React.PropTypes.bool,
     displayInput: React.PropTypes.bool,
+    displayCustom: React.PropTypes.func,
     angleArc: React.PropTypes.number,
     angleOffset: React.PropTypes.number,
   };
@@ -278,6 +279,28 @@ class Knob extends React.Component {
     ctx.stroke();
   }
 
+  renderCentre = () => {
+
+    if (this.props.displayInput) {
+      return (
+        <input
+          style={this.inputStyle()}
+          type="text"
+          value={this.props.value}
+          onChange={this.handleTextInput}
+          onKeyDown={this.handleArrowKey}
+          readOnly={this.props.readOnly || this.props.disableTextInput}
+        />
+      );
+
+    } else if (this.props.displayCustom && typeof this.props.displayCustom == 'function') {
+      return this.props.displayCustom();
+
+    } else {
+      return null;
+    }
+  };
+
   render = () => (
     <div
       style={{ width: this.w, height: this.h, display: 'inline-block' }}
@@ -288,17 +311,7 @@ class Knob extends React.Component {
         style={{ width: '100%', height: '100%' }}
         onMouseDown={this.props.readOnly ? null : this.handleMouseDown}
       />
-      {this.props.displayInput ?
-        <input
-          style={this.inputStyle()}
-          type="text"
-          value={this.props.value}
-          onChange={this.handleTextInput}
-          onKeyDown={this.handleArrowKey}
-          readOnly={this.props.readOnly || this.props.disableTextInput}
-        />
-        : null
-      }
+      {this.renderCentre()}
     </div>
   );
 }

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ class MyComponent extends React.Component {
 |`readOnly`|disable all user input|`false`|
 |`disableTextInput`|disable manual text input only|`false`|
 |`displayInput`|show numeric input box|`true`|
+|`displayCustom`|function that will render your custom component in the centre. (Make sure to set `displayInput` as `false`, as that takes priority)|n/a|
 |`angleArc`|arc size in degrees|`360`|
 |`angleOffset`|starting angle in degrees|`0`|
 

--- a/index.js
+++ b/index.js
@@ -161,6 +161,24 @@ var Knob = function (_React$Component) {
       };
     };
 
+    _this.renderCentre = function () {
+
+      if (_this.props.displayInput) {
+        return _react2.default.createElement('input', {
+          style: _this.inputStyle(),
+          type: 'text',
+          value: _this.props.value,
+          onChange: _this.handleTextInput,
+          onKeyDown: _this.handleArrowKey,
+          readOnly: _this.props.readOnly || _this.props.disableTextInput
+        });
+      } else if (_this.props.displayCustom && typeof _this.props.displayCustom == 'function') {
+        return _this.props.displayCustom();
+      } else {
+        return null;
+      }
+    };
+
     _this.render = function () {
       return _react2.default.createElement(
         'div',
@@ -175,14 +193,7 @@ var Knob = function (_React$Component) {
           style: { width: '100%', height: '100%' },
           onMouseDown: _this.props.readOnly ? null : _this.handleMouseDown
         }),
-        _this.props.displayInput ? _react2.default.createElement('input', {
-          style: _this.inputStyle(),
-          type: 'text',
-          value: _this.props.value,
-          onChange: _this.handleTextInput,
-          onKeyDown: _this.handleArrowKey,
-          readOnly: _this.props.readOnly || _this.props.disableTextInput
-        }) : null
+        _this.renderCentre()
       );
     };
 
@@ -269,6 +280,7 @@ Knob.propTypes = {
   readOnly: _react2.default.PropTypes.bool,
   disableTextInput: _react2.default.PropTypes.bool,
   displayInput: _react2.default.PropTypes.bool,
+  displayCustom: _react2.default.PropTypes.func,
   angleArc: _react2.default.PropTypes.number,
   angleOffset: _react2.default.PropTypes.number
 };


### PR DESCRIPTION
Hi @joshjg! Here is the second of the 3 PRs. I had a usecase of wanting to display icons in the centre, instead of the current value.

So, here is a more generalized solution that is backwards compatible. It hands control to the user, so that they can display what they want, and however they want. 

Thank you!