### PR TITLE
Add title to knob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 * Added prop to disable mouse wheel action.
+* Added prop to add title attribute on the wheel.
 
 # 0.3.0
 * Added boolean property `disableTextInput`

--- a/Knob.js
+++ b/Knob.js
@@ -29,6 +29,7 @@ class Knob extends React.Component {
     angleArc: React.PropTypes.number,
     angleOffset: React.PropTypes.number,
     disableMouseWheel: React.PropTypes.bool,
+    title: React.PropTypes.string,
   };
 
   static defaultProps = {
@@ -289,6 +290,7 @@ class Knob extends React.Component {
         ref={(ref) => { this.canvasRef = ref; }}
         style={{ width: '100%', height: '100%' }}
         onMouseDown={this.props.readOnly ? null : this.handleMouseDown}
+        title={this.props.title ? `${this.props.title}: ${this.props.value}` : this.props.value}
       />
       {this.props.displayInput ?
         <input

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ class MyComponent extends React.Component {
 |`angleArc`|arc size in degrees|`360`|
 |`angleOffset`|starting angle in degrees|`0`|
 |`disableMouseWheel`|disable changes on mouse wheel use|`false`|
+|`title`|adds title attribute to the wheel|`value`|
 
 ## Todo
 - [ ] Port `displayPrevious` feature

--- a/index.js
+++ b/index.js
@@ -173,7 +173,8 @@ var Knob = function (_React$Component) {
             _this.canvasRef = _ref;
           },
           style: { width: '100%', height: '100%' },
-          onMouseDown: _this.props.readOnly ? null : _this.handleMouseDown
+          onMouseDown: _this.props.readOnly ? null : _this.handleMouseDown,
+          title: _this.props.title ? _this.props.title + ': ' + _this.props.value : _this.props.value
         }),
         _this.props.displayInput ? _react2.default.createElement('input', {
           style: _this.inputStyle(),
@@ -271,7 +272,8 @@ Knob.propTypes = {
   displayInput: _react2.default.PropTypes.bool,
   angleArc: _react2.default.PropTypes.number,
   angleOffset: _react2.default.PropTypes.number,
-  disableMouseWheel: _react2.default.PropTypes.bool
+  disableMouseWheel: _react2.default.PropTypes.bool,
+  title: _react2.default.PropTypes.string
 };
 Knob.defaultProps = {
   min: 0,


### PR DESCRIPTION
Hi @joshjg! The final of the PRs - a very minor one. Just adds a title attribute to the wheel that shows up when someone hovers over it. Small win for accessibility.